### PR TITLE
Display info for multiple github accounts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -81,6 +81,7 @@ params:
   github:
     id: ""
     minStars: 5
+    ids: []
 
   twitter:
     enabled: true

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -317,6 +317,7 @@ params:
   github:
     id: "torvalds" # github user id
     minStars: 5 # 最小 star 项目 / min stars
+    ids: ["torvalds", "Ice-Hazymoon"]
 
   # Twitter 页面设置
   # tweet page

--- a/exampleSite/content/en-us/github.md
+++ b/exampleSite/content/en-us/github.md
@@ -1,5 +1,5 @@
 ---
 title: "GitHub"
 date: 2021-08-23T15:26:35+08:00
-layout: "github"
+layout: "github-multiple"
 ---

--- a/layouts/_default/github-multiple.html
+++ b/layouts/_default/github-multiple.html
@@ -1,0 +1,73 @@
+{{/* Allows you to display github info about multiple accounts */}}
+{{/* uses `ids` param */}}
+{{/* E.g. `ids = ["DaveSaah", "Ice-Hazymoon"]` */}}
+
+{{- define "main" -}}
+    {{- $githubConfig := .Site.Params.github -}}
+    <div class="page-github relative py-8">
+        {{- range $id := $githubConfig.ids -}}
+            <div class="mx-6 mb-2 inline-flex items-end pb-3 text-3xl md:mx-10">
+                <div class="mr-4 inline-flex items-center leading-none">
+                    <i class="eva eva-github-outline mr-2"></i>
+		    <span>{{- $.Title -}}</span>
+                </div>
+                <div class="inline-block text-lg leading-none text-gray-500 hover:text-theme dark:text-darkTextPlaceholder">
+                    <a href="https://github.com/{{- $id -}}/" target="_blank" rel="noopener noreferrer" title="{{- T "github.goto" -}}"
+                        >@{{- $id -}}</a
+                    >
+                </div>
+            </div>
+
+            <div class="mx-2 md:mx-6" id="github">
+                {{- $githubColors := $.Site.Data.luna.githubColors -}}
+                {{- $apiURL := print "https://api.github.com/users/" $id "/repos?per_page=100&type=owner" -}}
+                {{- $githubData := getJSON $apiURL -}}
+                {{- range sort $githubData "stargazers_count" "desc" -}}
+                    {{- if and (eq .owner.login $id) (gt .stargazers_count $githubConfig.minStars) -}}
+                        <a href="{{- .html_url -}}" target="_blank" rel="noopener noreferrer" class="inline-flex w-full  flex-col  justify-between sm:w-1/2">
+                            <div
+                                class="card relative m-4 flex h-40 flex-col justify-between rounded border p-4 transition duration-300 ease-[ease] dark:border-darkBorder dark:bg-darkBgAccent dark:shadow-none sm:border-none"
+                            >
+                                <div class="z-10">
+                                    <div class="text-lg font-bold" title="{{- .name -}}">
+                                        {{- .name -}}
+                                    </div>
+                                    <div class="my-3 line-clamp-2" title="{{- or .description "My awesome project" -}}">
+                                        {{- or .description "My awesome project" -}}
+                                    </div>
+                                </div>
+                                <div class="z-10 flex justify-between">
+                                    <div class="flex">
+                                        <div class="mr-6 flex items-center">
+                                            <i class="eva eva-star mr-1 text-amber-400"></i>
+                                            <span>{{- .stargazers_count -}}</span>
+                                        </div>
+
+                                        {{- if .language -}}
+                                            <div class="flex items-center">
+                                                <span class="github-language-dot" style="background-color:{{- index $githubColors .language -}};"></span>
+                                                <span>{{- .language -}}</span>
+                                            </div>
+                                        {{- end -}}
+                                    </div>
+
+                                    <div class="flex items-center">
+                                        <i class="eva eva-shuffle-2 mr-1 text-blue-500"></i>
+                                        <span>{{- .forks -}}</span>
+                                    </div>
+                                </div>
+
+                                <div class=" absolute right-0 text-9xl text-gray-50 dark:text-darkBorder">
+                                    <i class="eva eva-github-outline"></i>
+                                </div>
+                            </div>
+                        </a>
+                    {{- end -}}
+                {{- end -}}
+            </div>
+        {{- else -}}
+            {{- warnf "!!! GitHub ID not set, Please check your config file" -}}
+            <div class=" text-xl">ERROR: {{- T "github.config" -}}</div>
+        {{- end -}}
+    </div>
+{{- end -}}


### PR DESCRIPTION
## Files Changed

- config.yaml
- exampleSite/content/en-us/github.md

## File Added

- layouts/_default/github-multiple.html

## Function

Displays information about multiple GitHub accounts on the same page.

> Discussion: #65 