### PR TITLE
Fix deployment on Vercel

### DIFF
--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -3,8 +3,8 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.150.0"
-  NODE_VERSION = "22.19.0"
+  HUGO_VERSION = "0.150.1"
+  NODE_VERSION = "22.20.0"
 
 [[plugins]]
     package = "netlify-plugin-hugo-cache-resources"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@
   publish = "exampleSite/public"
 
 [build.environment]
-  HUGO_VERSION = "0.150.0"
-  NODE_VERSION = "22.19.0"
+  HUGO_VERSION = "0.150.1"
+  NODE_VERSION = "22.20.0"
   GO_VERSION = "1.25.1"
   HUGO_THEME = "repo"
 

--- a/package.json
+++ b/package.json
@@ -44,13 +44,16 @@
         "medium-zoom": "^1.1.0",
         "normalize.css": "^8.0.1",
         "pangu": "^4.0.7",
-        "postcss": "^8.5.3",
-        "prettier": "^3.5.3",
+        "postcss": "^8.5.6",
+        "prettier": "^3.6.2",
         "prettier-plugin-go-template": "^0.0.15",
-        "prettier-plugin-tailwindcss": "^0.5.14",
+        "prettier-plugin-tailwindcss": "^0.6.4",
         "swup": "^4.8.1",
         "swup-morph-plugin": "^1.3.0",
         "vanilla-lazyload": "^17.9.0"
+    },
+        "engines": {
+        "node": "22.x"
     },
     "browserslist": [
         "last 1 Chrome versions"

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
     "public": true,
     "build": {
         "env": {
-            "HUGO_VERSION": "0.146.0",
+            "HUGO_VERSION": "0.150.1",
             "HUGO_THEME": "path0"
         }
     },


### PR DESCRIPTION
This PR tries to fix deployment on Vercel.

Currently the deployment on Vercel [fails](https://vercel.com/icehazymoons-projects/hugo-theme-luna/HjpfrwxxV8qn81va5zxPqesS6mPr), this is the error message:

```
Error: Node.js Version "18.x" is discontinued and must be upgraded.
Please set Node.js Version to 22.x in your Project Settings to use Node.js 22.
```