### PR TITLE
Fix deprecation warnings, bump dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: "22.x"
 
       - name: Install Theme
-        run: yarn install --production
+        run: yarn install --omit=dev
 
       - name: Install PostCSS-CLI
         run: npm install postcss-cli -g
@@ -32,7 +32,7 @@ jobs:
       - name: Setup hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.150.0"
+          hugo-version: "0.150.1"
           extended: true
 
       - name: Build Hugo

--- a/.github/workflows/main_example.yml
+++ b/.github/workflows/main_example.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: "24.x"
 
       - name: Install Theme
-        run: cd themes/hugo-theme-luna && yarn install --production
+        run: cd themes/hugo-theme-luna && yarn install --omit=dev
 
       - name: Install PostCSS-CLI
         run: npm install postcss-cli -g
@@ -34,7 +34,7 @@ jobs:
       - name: Setup hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.150.0"
+          hugo-version: "0.150.1"
           extended: true
 
       - name: Build Hugo

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 ### - 📋 Requirements
 
 - **hugo-extended** >= 0.146.0
-- **NodeJs** >= 16.0.0
+- **NodeJs** >= 20.0.0
 - **postcss-cli**, Install using `npm install postcss-cli -g`
 
 ### - 📥 Install as git submodule
@@ -80,7 +80,7 @@
 ```bash
 git submodule add -b master https://github.com/Ice-Hazymoon/hugo-theme-luna themes/hugo-theme-luna
 cd themes/hugo-theme-luna
-npm install --production
+npm install --omit=dev
 ```
 
 There is a [`hugo.yaml`](exampleSite/hugo.yaml) file in the [`exampleSite`](exampleSite) directory, copy the file to your site directory and modify the contents.
@@ -115,14 +115,14 @@ Refer to [vercel.json](https://github.com/Ice-Hazymoon/hugo-theme-luna/blob/mast
 Environment variables
 
 ```
-HUGO_VERSION: 0.150.0
-NODE_VERSION: 22.19.0
+HUGO_VERSION: 0.150.1
+NODE_VERSION: 22.20.0
 ```
 
 Build command
 
 ```bash
-cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --production && cd ../../ && hugo --gc --minify --cleanDestinationDir --enableGitInfo
+cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --omit=dev && cd ../../ && hugo --gc --minify --cleanDestinationDir --enableGitInfo
 ```
 
 Build output directory

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,7 +73,7 @@
 注意，在使用该主题之前，请确保你遵循以下环境
 
 - **hugo-extended** 版本 >= 0.146.0
-- **NodeJs** >= 16.0.0
+- **NodeJs** >= 20.0.0
 - 已安装 **postcss-cli**，使用 `npm install postcss-cli -g` 安装
 
 第一次使用 Hugo 可以参考官方的安装手册：[https://gohugo.io/getting-started/installing/](https://gohugo.io/getting-started/installing/)
@@ -89,7 +89,7 @@ scoop install hugo-extended
 ```bash
 git submodule add -b master https://github.com/Ice-Hazymoon/hugo-theme-luna themes/hugo-theme-luna
 cd themes/hugo-theme-luna
-npm install --production
+npm install --omit=dev
 ```
 
 在主题 [`exampleSite`](exampleSite) 目录有一个 [`hugo.yaml`](exampleSite/hugo.yaml) 文件，将该文件复制到你的站点目录下并根据需求修改相关内容。
@@ -119,14 +119,14 @@ Environment variables
 
 ```
 HUGO_THEME: repo
-HUGO_VERSION: 0.150.0
-NODE_VERSION: 22.19.0
+HUGO_VERSION: 0.150.1
+NODE_VERSION: 22.20.0
 ```
 
 Build command
 
 ```bash
-$ cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --production && cd ../../ && hugo --gc --minify --cleanDestinationDir --enableGitInfo
+$ cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --omit=dev && cd ../../ && hugo --gc --minify --cleanDestinationDir --enableGitInfo
 ```
 
 Build output directory

--- a/exampleSite/netlify.toml
+++ b/exampleSite/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --production && cd ../../ && hugo --gc --minify --cleanDestinationDir --enableGitInfo"
+  command = "cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --omit=dev && cd ../../ && hugo --gc --minify --cleanDestinationDir --enableGitInfo"
   publish = "public"
 
 [build.environment]

--- a/exampleSite/vercel.json
+++ b/exampleSite/vercel.json
@@ -6,6 +6,6 @@
         }
     },
     "buildCommand": "hugo --gc --minify --cleanDestinationDir --enableGitInfo",
-    "installCommand": "cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --production && cd ../../",
+    "installCommand": "cd themes/hugo-theme-luna && npm install postcss-cli -g && npm install --omit=dev && cd ../../",
     "outputDirectory": "public"
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm install --production && hugo --gc --minify --cleanDestinationDir  -s ./exampleSite --themesDir ../.. --enableGitInfo"
+  command = "npm install --omit=dev && hugo --gc --minify --cleanDestinationDir  -s ./exampleSite --themesDir ../.. --enableGitInfo"
   publish = "exampleSite/public"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
         "autoprefixer": "^10.4.21",
         "cssnano": "^6.1.2",
         "cssnano-preset-advanced": "^6.1.2",
-        "postcss-cli": "^10.1.0",
+        "postcss-cli": "^11.0.1",
         "postcss-easing-gradients": "^3.0.1",
         "postcss-font-display": "^0.3.0",
         "postcss-pxtorem": "^6.1.0",
-        "postcss-replace-values": "^2.3.0",
+        "postcss-replace-values": "^3.0.2",
         "tailwindcss": "^3.4.17"
     },
     "devDependencies": {
@@ -48,9 +48,9 @@
         "prettier": "^3.6.2",
         "prettier-plugin-go-template": "^0.0.15",
         "prettier-plugin-tailwindcss": "^0.6.4",
-        "swup": "^4.8.1",
+        "swup": "^4.8.2",
         "swup-morph-plugin": "^1.3.0",
-        "vanilla-lazyload": "^17.9.0"
+        "vanilla-lazyload": "^19.1.3"
     },
         "engines": {
         "node": "22.x"

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,6 @@
         }
     },
     "buildCommand": "hugo --gc --minify --cleanDestinationDir  -s ./exampleSite --themesDir ../.. --enableGitInfo",
-    "installCommand": "npm install postcss-cli -g && npm install --production",
+    "installCommand": "npm install postcss-cli -g && npm install --omit=dev",
     "outputDirectory": "exampleSite/public"
 }


### PR DESCRIPTION
In the latest deployment logs, a warning message appears:

```
npm warn config production Use `--omit=dev` instead.
```
 This PF fixes these warnings.

It also bumps some dependencies in `package.json'.


